### PR TITLE
Run specs against real redis as well; refactor Action's scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 .idea
 .DS_Store
+.ruby-version
+.spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: ruby
 rvm:
-  - 2.3.3
-  - 2.4.3
-  - 2.5.0
-script: "bundle exec rake || ( sleep 1; bundle exec rspec --only-failures ) "
+- 2.3.3
+- 2.4.3
+- 2.5.0
+cache:
+- bundler
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+script: 'bundle exec rake || ( sleep 1; bundle exec rspec --only-failures ) '
 services:
-  - redis-server
+- redis-server
 notifications:
   email:
     recipients:
-      - kigster@gmail.com
+    - kigster@gmail.com
     on_success: never
     on_failure: always
+env:
+  global:
+    secure: bkq6cFUhMqn2ppqUPNax5biIivGw7uuOf1+pK4o9EFsi2qkuzLMQMulwmKC+RMLUMsaITkvec3Lp+kHwRYiXr4bxiFaBg+Q278W9o+mRWcBEh6mGnDVCgR13xdMfDZFrafEm44jEnOWJICkBlmdfMkMOriJUTowc8g745jpGEUNEu7ZqIsVFSflb+GcdYXhlouEThhkcwcdmRwkXqfq7pp8AEhiji2V5PNKiVY+Zu/lq9APAqMqFmXDZ0+SAjkeagSSCtLiXYQqc4Z1PU2Jvyov7nfDJ72VYqvfqevSe9+rqitOleR/BvIoIsGO+et7Dq94liK964fzP+spp1ODUMdhbC7tmBuYqYr3lxsK5S6bHZ9/LABHKOMbpKVJefrxmyh/QaQpjA5w3vuSkNZXD/OsZ0ddmHOvya6cv5sTX//muJVmba88IMCcmQSAZUIYK8796ACnnvDhlQ9n/ilOYzP69W+RmkyX09SH2VR9AeMSjwRESCOh0XYMevHNIjfOk24nPnsH5OT317p8dyCfn9Z+dif1iTEujRAqAzGh6AmWQNQQx6HEC8QDQGOMpLmOzlLWeQMgo90KOe78JA4iGGmVfbFvB/qJcZ4ZacG+s8tlLU8ADcq7yj2sYCHZOEatpQZbNAMjJwoZMyqojhCZgtH039LxwDXoD4/u0epk+RuY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - ./cc-test-reporter before-build
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-script: 'bundle exec rake || ( sleep 1; bundle exec rspec --only-failures ) '
+script: bin/spec
 services:
 - redis-server
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.3.3
   - 2.4.3
   - 2.5.0
-script: "bundle exec rake || bundle exec rspec --only-failures"
+script: "bundle exec rake || ( sleep 1; bundle exec rspec --only-failures ) "
 services:
   - redis-server
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: ruby
 rvm:
   - 2.3.3
-  - 2.4.0
-script: "bundle exec rake"
+  - 2.4.3
+  - 2.5.0
+script: "bundle exec rake || bundle exec rspec --only-failures"
 services:
   - redis-server
 notifications:
   email:
     recipients:
-      - dev-info@wanelo.com
       - kigster@gmail.com
     on_success: never
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.3.3
   - 2.4.0
 script: "bundle exec rspec"
+services:
+  - redis-server
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.3.3
   - 2.4.0
 script: "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ rvm:
   - 1.9.3
   - 2.3.3
   - 2.4.0
-script: "bundle exec rspec"
+script: "bundle exec rake"
 services:
   - redis-server
 notifications:
   email:
     recipients:
+      - dev-info@wanelo.com
       - kigster@gmail.com
     on_success: never
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.3.3
+  - 2.4.0
 script: "bundle exec rspec"
 notifications:
   email:
     recipients:
-      - dev-info@wanelo.com
+      - kigster@gmail.com
     on_success: never
     on_failure: always

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pause.gemspec
 gemspec
-
-gem 'fakeredis'
-gem 'guard-rspec'
-gem 'pry-nav'
-gem 'rake'
-gem 'rb-fsevent'
-gem 'rspec'
-gem 'timecop'

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Wanelo, Inc
+Copyright © 2018 Konstantin Gredeskoul, Atasay Gokkaya, Eric Saxby, Paul Henry
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/kigster/pause.svg?branch=master)](https://travis-ci.org/kigster/pause)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/af443a25cc902e629c8f/test_coverage)](https://codeclimate.com/github/kigster/pause/test_coverage)
 
-[![Gem Version](https://badge.fury.io/rb/pause.png)](https://badge.fury.io/rb/pause)
+[![Gem Version](https://badge.fury.io/rb/pause.svg)](https://badge.fury.io/rb/pause.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/af443a25cc902e629c8f/maintainability)](https://codeclimate.com/github/kigster/pause/maintainability)
 
 # Pause

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+[![Build Status](https://travis-ci.org/kigster/pause.svg?branch=master)](https://travis-ci.org/kigster/pause)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/af443a25cc902e629c8f/test_coverage)](https://codeclimate.com/github/kigster/pause/test_coverage)
+
+[![Gem Version](https://badge.fury.io/rb/pause.png)](https://badge.fury.io/rb/pause)
+[![Maintainability](https://api.codeclimate.com/v1/badges/af443a25cc902e629c8f/maintainability)](https://codeclimate.com/github/kigster/pause/maintainability)
+
 # Pause
 
-[![Gem Version](https://badge.fury.io/rb/pause.png)](http://badge.fury.io/rb/pause)
-[![Build Status](https://travis-ci.org/kigster/pause.svg?branch=master)](https://travis-ci.org/kigster/pause)
-
 ## In a Nutshell
+
 
 **Pause** is a fast and very flexible Redis-backed rate-limiter. You can use it to track events, with
 rules around how often they are allowed to occur within configured time checks.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,26 @@ tracked identifiers.
 
 The action block list is implemented as a sorted set, so it should still be usable when sharding.
 
+## Testing
+
+By default, `fakeredis` gem is used to emulate Redis in development. However, the same test-suite should be able to run against a real redis — however, be aware that it will flush the current db during spec run. In order to run specs against real redis, make sure you have Redis running locally on the default port, and that you are able to connect to it using `redis-cli`.
+
+Please note that Travis suite, as well as the default rake task, run both.
+
+### Unit Testing with Fakeredis
+
+Fakeredis is the default, and is also run whenever `bundle exec rspec` is executed, or `rake spec` task invoked.
+
+```bash
+bundle exec rake spec:unit
+```
+
+### Integration Testing with Redis
+
+```bash
+bundle exec rake spec:integration
+```
+
 ## Contributing
 
 Want to make it better? Cool. Here's how:

--- a/README.md
+++ b/README.md
@@ -50,15 +50,20 @@ Pause.configure do |config|
   config.redis_port = 6379
   config.redis_db   = 1
   
-  # aggregate all events into 10 minute blocks. 
-  # Larger blocks require less RAM and CPU, smaller blocks are more 
-  # computationally expensive.
-  config.resolution = 600
-       
-  # discard all events older than 1 day
-  config.history    = 86400   
+  config.resolution = 600     
+  config.history    = 7 * 86400  # discard events older than 7 days   
 end
 ```
+
+> NOTE: **resolution** is an setting that's key to understanding how Pause works. It represents the length of time during which similar events are aggregated into a Hash-like object, where the key is the identifier, and the value is the count within that period.
+> 
+> Because of this,
+>  
+>   * _Larger resolution requires less RAM and CPU and are faster to compute_
+>   * _Smaller resolution is more computationally expensive, but provides higher granularity_.
+>
+> The resolution setting must set to the smallest rate-limit period across all of your checks. Below it is set to 10 minutes, meaning that you can use Pause to **rate limit any event to no more than N times within a period of 10 minutes or more.**
+
 
 #### Define Rate Limited "Action"
 
@@ -69,12 +74,21 @@ module MyApp
   class UserNotificationLimiter < ::Pause::Action
     # this is a redis key namespace added to all data in this action
     scope 'un'  
-    check period_seconds:       120, max_allowed: 1
-    check period_seconds:     86400, max_allowed: 3
-    check period_seconds: 7 * 86400, max_allowed: 7
+    
+    check period_seconds:      120, 
+          max_allowed:           1, 
+          block_ttl:           240
+          
+    check period_seconds:    86400, 
+          max_allowed:           3
+          
+    check period_seconds: 7 *86400, 
+          max_allowed:           7
   end
 end
 ```
+
+> NOTE: for each check, `block_ttl` defaults to `period_seconds`, and represents the duration of time the action will consider itself as "rate limited" after a particular check reaches the limit.  Note, that all actions will automatically leave the "rate limited" state after `block_ttl` seconds have passed.
 
 #### Perform operation, but only if the user is not rate-limited
 
@@ -83,17 +97,18 @@ Now we simply instantiate this limiter by passing user ID (any unique identifier
 ```ruby
 class NotificationsWorker
   def perform(user_id)
-    limiter = MyApp::UserNotificationLimiter.new(user_id)
-    
-    limiter.unless_rate_limited do
-      user = User.find(user_id) 
-      user.send_push_notification!
-    end
-    
-    # You can also do something in case the user is rate limited:
-    limiter.if_rate_limited do |rate_limit_event|
-      Rails.logger.info("user #{user.id} has exceeded rate limit: #{rate_limit_event}") 
-    end
+    MyApp::UserNotificationLimiter.new(user_id) do 
+      unless_rate_limited do
+        # this block ONLY runs if rate limit is not reached
+        user = User.find(user_id) 
+        user.send_push_notification!
+      end
+      
+      if_rate_limited do |rate_limit_event|
+        # this block ONLY runs if the action has reached it's rate limit.
+        Rails.logger.info("user #{user.id} has exceeded rate limit: #{rate_limit_event}") 
+      end
+    end   
   end
 end
 ```
@@ -339,8 +354,10 @@ Want to make it better? Cool. Here's how:
 
 ## Authors
 
-This gem was written by Eric Saxby, Atasay Gokkaya and Konstantin Gredeskoul at Wanelo, Inc.
+ * This gem was written by Eric Saxby, Atasay Gokkaya and Konstantin Gredeskoul at Wanelo, Inc.
+ * It's been updated and refreshed by Konstantin Gredeskoul.
 
-Please see the LICENSE.txt file for further details.
+
+Please see the [LICENSE.txt](LICENSE.txt) file for further details.
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,17 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task :default => [ 'spec:unit', 'spec:integration' ]
+
+namespace :spec do
+  desc 'Run specs using fakeredis'
+  task :unit do
+    ENV['PAUSE_REAL_REDIS'] = nil
+    Rake::Task["spec"].execute
+  end
+  desc 'Run specs against a local Redis server'
+  task :integration do
+    ENV['PAUSE_REAL_REDIS'] = 'true'
+    Rake::Task["spec"].execute
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,47 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'yard'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => [ 'spec:unit', 'spec:integration' ]
+task :default => %w(spec:unit spec:integration)
 
 namespace :spec do
   desc 'Run specs using fakeredis'
   task :unit do
     ENV['PAUSE_REAL_REDIS'] = nil
-    Rake::Task["spec"].execute
+    Rake::Task['spec'].execute
   end
   desc 'Run specs against a local Redis server'
   task :integration do
     ENV['PAUSE_REAL_REDIS'] = 'true'
-    Rake::Task["spec"].execute
+    Rake::Task['spec'].execute
   end
 end
+
+def shell(*args)
+  puts "running: #{args.join(' ')}"
+  system(args.join(' '))
+end
+
+task :clean do
+  shell('rm -rf pkg/ tmp/ coverage/ doc/ ' )
+end
+
+task :gem => [:build] do
+  shell('gem install pkg/*')
+end
+
+task :permissions => [ :clean ] do
+  shell('chmod -v o+r,g+r * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*')
+  shell("find . -type d -exec chmod o+x,g+x {} \\;")
+end
+
+task :build => :permissions
+
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = %w(lib/**/*.rb exe/*.rb - README.md LICENSE.txt)
+  t.options.unshift('--title','"Pause - Redis-backed Rate Limiter"')
+  t.after = ->() { exec('open doc/index.html') }
+end
+

--- a/bin/spec
+++ b/bin/spec
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+retry-errors() {
+  sleep 1
+  bundle exec rspec --only-failures
+}
+
+specs() {
+  bundle exec rspec && \
+    PAUSE_REAL_REDIS=true bundle exec rspec
+}
+
+specs || retry-errors
+

--- a/lib/pause.rb
+++ b/lib/pause.rb
@@ -37,11 +37,11 @@ module Pause
     end
 
     def configure(&block)
-      @configuration = Pause::Configuration.new.configure(&block)
+      @configuration ||= Pause::Configuration.new.configure(&block)
     end
 
-    def config
-      @configuration
+    def config(&block)
+      configure(&block)
     end
   end
 end

--- a/lib/pause.rb
+++ b/lib/pause.rb
@@ -1,4 +1,5 @@
 require 'redis'
+require 'colored2'
 require 'pause/version'
 require 'pause/configuration'
 require 'pause/action'

--- a/lib/pause/action.rb
+++ b/lib/pause/action.rb
@@ -2,9 +2,10 @@ module Pause
   class Action
     attr_accessor :identifier
 
-    def initialize(identifier)
+    def initialize(identifier, &block)
       @identifier       = identifier
       self.class.checks ||= []
+      instance_exec(&block) if block
     end
 
     def scope

--- a/lib/pause/action.rb
+++ b/lib/pause/action.rb
@@ -4,7 +4,7 @@ module Pause
 
     def initialize(identifier)
       @identifier       = identifier
-      self.class.checks = [] unless self.class.instance_variable_get(:@checks)
+      self.class.checks ||= []
     end
 
     def scope

--- a/lib/pause/action.rb
+++ b/lib/pause/action.rb
@@ -3,58 +3,109 @@ module Pause
     attr_accessor :identifier
 
     def initialize(identifier)
-      @identifier = identifier
+      @identifier       = identifier
       self.class.checks = [] unless self.class.instance_variable_get(:@checks)
     end
 
-    # Action subclasses should define their scope as follows
-    #
-    #     class MyAction < Pause::Action
-    #       scope "my:scope"
-    #     end
-    #
     def scope
-      raise 'Should implement scope. (Ex: ipn:follow)'
+      self.class.scope
     end
 
-    def self.scope(scope_identifier = nil)
-      class_variable_set(:@@class_scope, scope_identifier)
-      define_method(:scope) { scope_identifier }
-    end
+    class << self
+      attr_accessor :checks
 
-    # Action subclasses should define their checks as follows
-    #
-    #  period_seconds - compare all activity by an identifier within the time period
-    #  max_allowed    - if the number of actions by an identifier exceeds max_allowed for the time period marked
-    #                   by period_seconds, it is no longer ok.
-    #  block_ttl      - time to mark identifier as not ok
-    #
-    #     class MyAction < Pause::Action
-    #       check period_seconds: 60,   max_allowed: 100,  block_ttl: 3600
-    #       check period_seconds: 1800, max_allowed: 2000, block_ttl: 3600
-    #     end
-    #
-    def self.check(*args)
-      @checks ||= []
-      period_seconds, max_allowed, block_ttl =
-        if args.first.is_a?(Hash)
-          [args.first[:period_seconds], args.first[:max_allowed], args.first[:block_ttl]]
-        else
-          args
+      def inherited(klass)
+        klass.instance_eval do
+          # Action subclasses should define their scope as follows
+          #
+          #     class MyAction < Pause::Action
+          #       scope "my:scope"
+          #     end
+          #
+          @scope = klass.name.downcase.gsub(/::/, '.')
+          class << self
+
+            # @param [String] args
+            def scope(*args)
+              @scope = args.first if args && args.size == 1
+              @scope
+            end
+          end
         end
-      @checks << Pause::PeriodCheck.new(period_seconds, max_allowed, block_ttl)
-    end
+      end
 
-    def self.checks
-      @checks
+
+      # Actions can be globally disabled or re-enabled in a persistent
+      # way.
+      #
+      #   MyAction.disable
+      #   MyAction.enabled? => false
+      #   MyAction.disabled? => true
+      #
+      #   MyAction.enable
+      #   MyAction.enabled? => true
+      #   MyAction.disabled? => false
+      #
+      def enable
+        adapter.enable(scope)
+      end
+
+      def disable
+        adapter.disable(scope)
+      end
+
+      def enabled?
+        adapter.enabled?(scope)
+      end
+
+      def disabled?
+        !enabled?
+      end
+
+
+      # Action subclasses should define their checks as follows
+      #
+      #  period_seconds - compare all activity by an identifier within the time period
+      #  max_allowed    - if the number of actions by an identifier exceeds max_allowed for the time period marked
+      #                   by period_seconds, it is no longer ok.
+      #  block_ttl      - time to mark identifier as not ok
+      #
+      #     class MyAction < Pause::Action
+      #       check period_seconds: 60,   max_allowed: 100,  block_ttl: 3600
+      #       check period_seconds: 1800, max_allowed: 2000, block_ttl: 3600
+      #     end
+      #
+      def check(*args)
+        self.checks ||= []
+        params      =
+          if args.first.is_a?(Hash)
+            [args.first[:period_seconds], args.first[:max_allowed], args.first[:block_ttl]]
+          else
+            args
+          end
+        self.checks << Pause::PeriodCheck.new(*params)
+      end
+
+      def tracked_identifiers
+        adapter.all_keys(scope)
+      end
+
+      def rate_limited_identifiers
+        adapter.rate_limited_keys(scope)
+      end
+
+      def unblock_all
+        adapter.delete_rate_limited_keys(scope)
+      end
+
+      def adapter
+        Pause.adapter
+      end
+
     end
 
     def checks
       self.class.checks
-    end
-
-    def self.checks=(period_checks)
-      @checks = period_checks
     end
 
     def block_for(ttl)
@@ -66,7 +117,7 @@ module Pause
     end
 
     def rate_limited?
-      ! ok?
+      !ok?
     end
 
     def ok?
@@ -80,61 +131,15 @@ module Pause
       Pause.analyzer.check(self)
     end
 
-    def self.tracked_identifiers
-      adapter.all_keys(self.class_scope)
-    end
-
-    def self.rate_limited_identifiers
-      adapter.rate_limited_keys(self.class_scope)
-    end
-
-    def self.unblock_all
-      adapter.delete_rate_limited_keys(self.class_scope)
-    end
-
     def unblock
       adapter.delete_rate_limited_key(scope, identifier)
     end
 
-    # Actions can be globally disabled or re-enabled in a persistent
-    # way.
-    #
-    #   MyAction.disable
-    #   MyAction.enabled? => false
-    #   MyAction.disabled? => true
-    #
-    #   MyAction.enable
-    #   MyAction.enabled? => true
-    #   MyAction.disabled? => false
-    #
-    def self.enable
-      adapter.enable(class_scope)
-    end
-
-    def self.disable
-      adapter.disable(class_scope)
-    end
-
-    def self.enabled?
-      adapter.enabled?(class_scope)
-    end
-
-    def self.disabled?
-      ! enabled?
-    end
-
     private
-
-    def self.adapter
-      Pause.adapter
-    end
 
     def adapter
       self.class.adapter
     end
 
-    def self.class_scope
-      class_variable_get:@@class_scope if class_variable_defined?(:@@class_scope)
-    end
   end
 end

--- a/lib/pause/analyzer.rb
+++ b/lib/pause/analyzer.rb
@@ -10,8 +10,8 @@ module Pause
     # @return [nil]  everything is fine
     # @return [false]  this action is already blocked
     # @return [Pause::RateLimitedEvent]  the action was blocked as a result of this check
-    def check(action)
-      return false if adapter.rate_limited?(action.scope, action.identifier)
+    def check(action, recalculate: false)
+      return false if adapter.rate_limited?(action.scope, action.identifier) && !recalculate
       timestamp = period_marker(Pause.config.resolution, Time.now.to_i)
       set       = adapter.key_history(action.scope, action.identifier)
       action.checks.each do |period_check|

--- a/lib/pause/analyzer.rb
+++ b/lib/pause/analyzer.rb
@@ -13,7 +13,7 @@ module Pause
     def check(action)
       return false if adapter.rate_limited?(action.scope, action.identifier)
       timestamp = period_marker(Pause.config.resolution, Time.now.to_i)
-      set = adapter.key_history(action.scope, action.identifier)
+      set       = adapter.key_history(action.scope, action.identifier)
       action.checks.each do |period_check|
         start_time = timestamp - period_check.period_seconds
         set.reverse.inject(0) do |sum, element|

--- a/lib/pause/configuration.rb
+++ b/lib/pause/configuration.rb
@@ -3,7 +3,7 @@ module Pause
     attr_writer :redis_host, :redis_port, :redis_db, :resolution, :history, :sharded
 
     def configure
-      yield self
+      yield self if block_given?
       self
     end
 

--- a/lib/pause/logger.rb
+++ b/lib/pause/logger.rb
@@ -1,11 +1,11 @@
 module Pause
   class Logger
-    def self.puts message
+    def self.puts(message)
       STDOUT.puts message
     end
 
-    def self.fatal message
-      STDERR.puts message
+    def self.fatal(message)
+      STDERR.puts message.red
     end
   end
 end

--- a/lib/pause/redis/sharded_adapter.rb
+++ b/lib/pause/redis/sharded_adapter.rb
@@ -7,25 +7,20 @@ module Pause
     # Operations that are not possible when data is sharded
     # raise an error.
     class ShardedAdapter < Adapter
-      def increment(scope, identifier, timestamp, count = 1)
-        k = tracked_key(scope, identifier)
-        redis.zincrby k, count, period_marker(resolution, timestamp)
-        redis.expire k, history
 
-        if redis.zcard(k) > time_blocks_to_keep
-          list = extract_set_elements(k)
-          to_remove = list.slice(0, (list.size - time_blocks_to_keep))
-          redis.zrem(k, to_remove.map(&:ts))
-        end
+      # Overrides real multi which is not possible when sharded.
+      def with_multi
+        yield(redis) if block_given?
       end
 
+      protected
+
+      def redis_connection_opts
+        { host: Pause.config.redis_host,
+          port: Pause.config.redis_port }
+      end
 
       private
-
-      def redis
-        @redis_conn ||= ::Redis.new(host: Pause.config.redis_host,
-          port: Pause.config.redis_port)
-      end
 
       def keys(_key_scope)
         raise OperationNotSupported.new('Can not be executed when Pause is configured in sharded mode')

--- a/lib/pause/version.rb
+++ b/lib/pause/version.rb
@@ -1,3 +1,3 @@
 module Pause
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/lib/pause/version.rb
+++ b/lib/pause/version.rb
@@ -1,3 +1,3 @@
 module Pause
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/lib/pause/version.rb
+++ b/lib/pause/version.rb
@@ -1,3 +1,3 @@
 module Pause
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/pause.gemspec
+++ b/pause.gemspec
@@ -18,4 +18,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'redis'
+
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'guard-rspec'
+  gem.add_development_dependency 'pry-nav'
+  gem.add_development_dependency 'rb-fsevent'
+  gem.add_development_dependency 'timecop'
+  gem.add_development_dependency 'rake'
 end

--- a/pause.gemspec
+++ b/pause.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pause/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "pause"
+  gem.name          = 'pause'
   gem.version       = Pause::VERSION
-  gem.authors       = ["Atasay Gokkaya", "Paul Henry", "Eric Saxby", "Konstantin Gredeskoul"]
-  gem.email         = %w(atasay@wanelo.com paul@wanelo.com sax@wanelo.com kig@wanelo.com)
+  gem.authors       = ['Atasay Gokkaya', 'Paul Henry', 'Eric Saxby', 'Konstantin Gredeskoul']
+  gem.email         = %w(atasay@wanelo.com paul@wanelo.com sax@ericsaxby.com kigster@gmail.com)
   gem.description   = %q(Real time rate limiting for multi-process ruby environments based on Redis)
   gem.summary       = %q(RReal time rate limiting for multi-process ruby environments based on Redis)
-  gem.homepage      = "https://github.com/wanelo/pause"
+  gem.homepage      = 'https://github.com/wanelo/pause'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/pause.gemspec
+++ b/pause.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'redis'
   gem.add_dependency 'hiredis'
+  gem.add_dependency 'colored2'
 
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'yard'

--- a/pause.gemspec
+++ b/pause.gemspec
@@ -8,23 +8,23 @@ Gem::Specification.new do |gem|
   gem.version       = Pause::VERSION
   gem.authors       = ['Atasay Gokkaya', 'Paul Henry', 'Eric Saxby', 'Konstantin Gredeskoul']
   gem.email         = %w(atasay@wanelo.com paul@wanelo.com sax@ericsaxby.com kigster@gmail.com)
-  gem.summary       = %q(Fast and efficient real time rate limiting library for multi-process ruby environments based on Redis)
-  gem.description   = %q(This gem provides flexible and easy to use interface to define rate checks, register events as they come, and verify if the rate limit is reached. Multiple checks for the same metric are easily supported.)
-  gem.homepage      = 'https://github.com/wanelo/pause'
+  gem.summary       = %q(Fast, scalable, and flexible real time rate limiting library for distributed Ruby environments backed by Redis.)
+  gem.description   = %q(This gem provides highly flexible and easy to use interface to define rate limit checks, register events as they come, and verify if the rate limit is reached. Multiple checks for the same metric are easily supported. This gem is used at very high scale on several popular web sites.)
+  gem.homepage      = 'https://github.com/kigster/pause'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
   gem.add_dependency 'redis'
   gem.add_dependency 'hiredis'
 
+  gem.add_development_dependency 'simplecov'
+  gem.add_development_dependency 'yard'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'fakeredis'
   gem.add_development_dependency 'guard-rspec'
-  gem.add_development_dependency 'pry-nav'
-  gem.add_development_dependency 'rb-fsevent'
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'rake'
 end

--- a/pause.gemspec
+++ b/pause.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version       = Pause::VERSION
   gem.authors       = ['Atasay Gokkaya', 'Paul Henry', 'Eric Saxby', 'Konstantin Gredeskoul']
   gem.email         = %w(atasay@wanelo.com paul@wanelo.com sax@ericsaxby.com kigster@gmail.com)
-  gem.description   = %q(Real time rate limiting for multi-process ruby environments based on Redis)
-  gem.summary       = %q(RReal time rate limiting for multi-process ruby environments based on Redis)
+  gem.summary       = %q(Fast and efficient real time rate limiting library for multi-process ruby environments based on Redis)
+  gem.description   = %q(This gem provides flexible and easy to use interface to define rate checks, register events as they come, and verify if the rate limit is reached. Multiple checks for the same metric are easily supported.)
   gem.homepage      = 'https://github.com/wanelo/pause'
 
   gem.files         = `git ls-files`.split($/)
@@ -18,8 +18,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'redis'
+  gem.add_dependency 'hiredis'
 
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'fakeredis'
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'pry-nav'
   gem.add_development_dependency 'rb-fsevent'

--- a/spec/pause/action_spec.rb
+++ b/spec/pause/action_spec.rb
@@ -22,87 +22,119 @@ describe Pause::Action do
     allow(Pause).to receive(:adapter).and_return(adapter)
   end
 
-  let(:action) { MyNotification.new('1237612') }
-  let(:other_action) { MyNotification.new('1237613') }
+  let(:identifier) { '11112222' }
+  let(:action) { MyNotification.new(identifier) }
 
-  describe '#increment!' do
-    it 'should increment' do
-      time = Time.now
-      Timecop.freeze time do
-        expect(Pause.adapter).to receive(:increment).with(action.scope, '1237612', time.to_i, 1)
-        action.increment!
+  let(:other_identifier) { '8798734' }
+  let(:other_action) { MyNotification.new(other_identifier) }
+
+  RSpec.shared_examples 'an action' do
+    describe '#increment!' do
+      it 'should increment' do
+        time = Time.now
+        Timecop.freeze time do
+          expect(Pause.adapter).to receive(:increment).with(action.scope, identifier, time.to_i, 1)
+          action.increment!
+        end
       end
     end
-  end
 
-  describe '#ok?' do
-    it 'should successfully return if the action is blocked or not' do
-      time = Time.now
-      Timecop.freeze time do
-        4.times do
+    describe '#ok?' do
+      it 'should successfully return if the action is blocked or not' do
+        time = Time.now
+        Timecop.freeze time do
+          4.times do
+            action.increment!
+            expect(action.ok?).to be true
+          end
           action.increment!
+          expect(action.ok?).to be false
+        end
+      end
+
+      it 'should successfully consider different period checks' do
+        time = Time.parse('Sept 22, 11:34:00')
+
+        Timecop.freeze time - 30 do
+          action.increment! 4
           expect(action.ok?).to be true
         end
-        action.increment!
+
+        Timecop.freeze time do
+          action.increment! 2
+          expect(action.ok?).to be true
+        end
+
+        Timecop.freeze time do
+          action.increment! 1
+          expect(action.ok?).to be false
+        end
+      end
+
+      it 'should return false and silently fail if redis is not available' do
+        allow(Pause::Logger).to receive(:fatal)
+        allow_any_instance_of(Redis).to receive(:zrange).and_raise Redis::CannotConnectError
+        time = period_marker(resolution, Time.now.to_i)
+
+        action.increment! 4, time - 25
+
         expect(action.ok?).to be false
       end
     end
 
-    it 'should successfully consider different period checks' do
-      time = Time.parse('Sept 22, 11:34:00')
-
-      Timecop.freeze time - 30 do
-        action.increment! 4
-        expect(action.ok?).to be true
+    describe '#analyze' do
+      context 'action should not be rate limited' do
+        it 'returns nil' do
+          expect(adapter.rate_limited?(action.scope, action.identifier)).to be false
+          expect(action.analyze).to be nil
+        end
       end
 
-      Timecop.freeze time do
-        action.increment! 2
-        expect(action.ok?).to be true
-      end
+      context 'action should be rate limited' do
+        it 'returns a RateLimitedEvent object' do
+          time       = Time.now
+          rate_limit = nil
 
-      Timecop.freeze time do
-        action.increment! 1
-        expect(action.ok?).to be false
+          Timecop.freeze time do
+            7.times { action.increment! }
+            rate_limit = action.analyze
+          end
+
+          expected_rate_limit = Pause::RateLimitedEvent.new(action, action.checks[0], 7, time.to_i)
+
+          expect(rate_limit).to be_a(Pause::RateLimitedEvent)
+          expect(rate_limit.identifier).to eq(expected_rate_limit.identifier)
+          expect(rate_limit.sum).to eq(expected_rate_limit.sum)
+          expect(rate_limit.period_check).to eq(expected_rate_limit.period_check)
+          expect(rate_limit.timestamp).to eq(expected_rate_limit.timestamp)
+        end
       end
     end
 
-    it 'should return false and silently fail if redis is not available' do
-      allow(Pause::Logger).to receive(:fatal)
-      allow_any_instance_of(Redis).to receive(:zrange).and_raise Redis::CannotConnectError
-      time = period_marker(resolution, Time.now.to_i)
+    describe '#unblock' do
+      it 'unblocks the specified id' do
+        10.times { action.increment! }
+        expect(action.ok?).to be false
+        action.unblock
+        expect(action.ok?).to be true
+      end
+    end
 
-      action.increment! 4, time - 25
-
-      expect(action.ok?).to be false
+    describe '#block_for' do
+      it 'blocks the IP for N seconds' do
+        expect(adapter).to receive(:rate_limit!).with(action.scope, action.identifier, 10).and_call_original
+        action.block_for(10)
+        expect(action.ok?).to be false
+      end
     end
   end
 
-  describe '#analyze' do
-    context 'action should not be rate limited' do
-      it 'returns nil' do
-        expect(adapter.rate_limited?(action.scope, action.identifier)).to be false
-        expect(action.analyze).to be nil
-      end
-    end
-
-    context 'action should be rate limited' do
-      it 'returns a RateLimitedEvent object' do
-        time       = Time.now
-        rate_limit = nil
-
-        Timecop.freeze time do
-          7.times { action.increment! }
-          rate_limit = action.analyze
-        end
-
-        expected_rate_limit = Pause::RateLimitedEvent.new(action, action.checks[0], 7, time.to_i)
-
-        expect(rate_limit).to be_a(Pause::RateLimitedEvent)
-        expect(rate_limit.identifier).to eq(expected_rate_limit.identifier)
-        expect(rate_limit.sum).to eq(expected_rate_limit.sum)
-        expect(rate_limit.period_check).to eq(expected_rate_limit.period_check)
-        expect(rate_limit.timestamp).to eq(expected_rate_limit.timestamp)
+  context 'actions under test' do
+    ['123456', 'hello', 0, 999999].each do |id|
+      let(:identifier) { id }
+      let(:action) { MyNotification.new(identifier) }
+      describe "action with identifier #{id}" do
+        it_behaves_like 'an action'
       end
     end
   end
@@ -151,25 +183,6 @@ describe Pause::Action do
     end
   end
 
-  describe '#unblock' do
-    it 'unblocks the specified id' do
-      10.times { action.increment! }
-
-      expect(action.ok?).to be false
-
-      action.unblock
-
-      expect(action.ok?).to be true
-    end
-  end
-
-  describe '#block_for' do
-    it 'blocks the IP for N seconds' do
-      expect(adapter).to receive(:rate_limit!).with(action.scope, action.identifier, 10).and_call_original
-      action.block_for(10)
-      expect(action.ok?).to be false
-    end
-  end
 end
 
 describe Pause::Action, '.check' do
@@ -196,10 +209,10 @@ describe Pause::Action, '.check' do
   it 'should define a period check on new instances' do
     expect(ActionWithMultipleChecks.new('id').checks).to \
       eq([
-          Pause::PeriodCheck.new(100, 150, 200),
-          Pause::PeriodCheck.new(200, 150, 200),
-          Pause::PeriodCheck.new(300, 150, 200)
-        ])
+                                                                    Pause::PeriodCheck.new(100, 150, 200),
+                                                                    Pause::PeriodCheck.new(200, 150, 200),
+                                                                    Pause::PeriodCheck.new(300, 150, 200)
+                                                                  ])
   end
 
   it 'should accept hash arguments' do
@@ -207,7 +220,6 @@ describe Pause::Action, '.check' do
                                                           Pause::PeriodCheck.new(50, 100, 60)
                                                         ])
   end
-
 end
 
 describe Pause::Action, '.scope' do
@@ -215,7 +227,6 @@ describe Pause::Action, '.scope' do
     class NoScope < ::Pause::Action
     end
   end
-
 
   it 'should raise if scope is not defined' do
     expect(MyApp::NoScope.new('1.2.3.4').scope).to eq 'myapp.noscope'

--- a/spec/pause/action_spec.rb
+++ b/spec/pause/action_spec.rb
@@ -81,13 +81,14 @@ describe Pause::Action do
   describe '#analyze' do
     context 'action should not be rate limited' do
       it 'returns nil' do
+        expect(adapter.rate_limited?(action.scope, action.identifier)).to be false
         expect(action.analyze).to be nil
       end
     end
 
     context 'action should be rate limited' do
       it 'returns a RateLimitedEvent object' do
-        time = Time.now
+        time       = Time.now
         rate_limit = nil
 
         Timecop.freeze time do
@@ -188,12 +189,13 @@ describe Pause::Action, '.check' do
 
   it 'should define a period check on new instances' do
     expect(ActionWithCheck.new('id').checks).to eq([
-          Pause::PeriodCheck.new(100, 150, 200)
-        ])
+                                                     Pause::PeriodCheck.new(100, 150, 200)
+                                                   ])
   end
 
   it 'should define a period check on new instances' do
-    expect(ActionWithMultipleChecks.new('id').checks).to eq([
+    expect(ActionWithMultipleChecks.new('id').checks).to \
+      eq([
           Pause::PeriodCheck.new(100, 150, 200),
           Pause::PeriodCheck.new(200, 150, 200),
           Pause::PeriodCheck.new(300, 150, 200)
@@ -202,20 +204,21 @@ describe Pause::Action, '.check' do
 
   it 'should accept hash arguments' do
     expect(ActionWithHashChecks.new('id').checks).to eq([
-          Pause::PeriodCheck.new(50, 100, 60)
-        ])
+                                                          Pause::PeriodCheck.new(50, 100, 60)
+                                                        ])
   end
 
 end
 
 describe Pause::Action, '.scope' do
-  class UndefinedScopeAction < Pause::Action
+  module MyApp
+    class NoScope < ::Pause::Action
+    end
   end
 
+
   it 'should raise if scope is not defined' do
-    expect {
-      UndefinedScopeAction.new('1.2.3.4').scope
-    }.to raise_error('Should implement scope. (Ex: ipn:follow)')
+    expect(MyApp::NoScope.new('1.2.3.4').scope).to eq 'myapp.noscope'
   end
 
   class DefinedScopeAction < Pause::Action
@@ -236,7 +239,7 @@ describe Pause::Action, 'enabled/disabled states' do
   before do
     Pause.configure do |c|
       c.resolution = 10
-      c.history = 10
+      c.history    = 10
     end
   end
 

--- a/spec/pause/logger_spec.rb
+++ b/spec/pause/logger_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Pause::Logger do
+  before do
+    expect(STDOUT).to receive(:puts).with('hello')
+    expect(STDERR).to receive(:puts).with('whoops'.red)
+  end
+
+  it 'will call through STDOUT/STDERR' do
+    described_class.puts('hello')
+    described_class.fatal('whoops')
+  end
+end

--- a/spec/pause/redis/adapter_spec.rb
+++ b/spec/pause/redis/adapter_spec.rb
@@ -31,17 +31,29 @@ describe Pause::Redis::Adapter do
       expect(set[0].size).to eql(2)
     end
 
-    it 'should remove old key from a redis set' do
-      time = Time.now
-      expect(redis_conn).to receive(:zrem).with(tracked_key, [adapter.period_marker(resolution, time)])
+    RSpec.shared_examples 'removes old elements' do
+      let(:time) { Time.now }
+      before do
+        to_delete.times do |t|
+          expect(redis_conn).to receive(:zrem).with(tracked_key, [adapter.period_marker(resolution, time + t)]).once
+        end
+        adapter.time_blocks_to_keep = 1
+      end
+      it 'should remove old elements' do
+        Timecop.freeze time do
+          adapter.increment(scope, identifier, Time.now.to_i)
+        end
+        to_delete.times do |t|
+          Timecop.freeze time + (adapter.resolution + t + 1) do
+            adapter.increment(scope, identifier, Time.now.to_i)
+          end
+        end
+      end
+    end
 
-      adapter.time_blocks_to_keep = 1
-      Timecop.freeze time do
-        adapter.increment(scope, identifier, Time.now.to_i)
-      end
-      Timecop.freeze time + (adapter.resolution + 1) do
-        adapter.increment(scope, identifier, Time.now.to_i)
-      end
+    context 'removing two elements' do
+      let(:to_delete) { 2 }
+      it_behaves_like 'removes old elements'
     end
 
     it 'sets expiry on key' do

--- a/spec/pause/redis/sharded_adapter_spec.rb
+++ b/spec/pause/redis/sharded_adapter_spec.rb
@@ -21,4 +21,18 @@ describe Pause::Redis::ShardedAdapter do
       expect { adapter.all_keys('cake') }.to raise_error(Pause::Redis::OperationNotSupported)
     end
   end
+
+  describe '#with_multi' do
+    let(:redis) { adapter.send(:redis) }
+    it 'should not call redis.multi' do
+      expect(redis).to_not receive(:multi)
+      expect { adapter.increment(:scope, 123, Time.now) }.to_not raise_error
+    end
+  end
+
+  describe '#redis' do
+    it 'should not use redis db when connecting' do
+      expect(adapter.send(:redis_connection_opts)).to_not include(:db)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,12 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'pause'
 require 'fileutils'
+
+require 'simplecov'
+SimpleCov.start
+
+require 'pause'
 
 if ENV['PAUSE_REAL_REDIS']
   require 'pause/redis/adapter'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 require 'pause'
 require 'pry'
+require 'pause/redis/adapter'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
@@ -20,4 +21,7 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+  config.before(:example) do
+    Pause::Redis::Adapter.redis.flushdb
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,12 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 require 'pause'
 require 'pry'
-require 'pause/redis/adapter'
+
+if ENV['PAUSE_REAL_REDIS']
+  require 'pause/redis/adapter'
+else
+  require 'fakeredis/rspec'
+end
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
@@ -21,7 +26,9 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
-  config.before(:example) do
-    Pause::Redis::Adapter.redis.flushdb
+  if ENV['PAUSE_REAL_REDIS']
+    config.before(:example) do
+      Pause::Redis::Adapter.redis.flushdb
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'rubygems'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 require 'pause'
 require 'pry'
-require 'support/fakeredis'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'pry'
 
 if ENV['PAUSE_REAL_REDIS']
   require 'pause/redis/adapter'
+  puts "\n==> Using real Redis-server at #{Pause::Redis::Adapter.redis.inspect}\n\n"
 else
   require 'fakeredis/rspec'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,15 +5,12 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'rubygems'
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 require 'pause'
-require 'pry'
+require 'fileutils'
 
 if ENV['PAUSE_REAL_REDIS']
   require 'pause/redis/adapter'
-  puts "\n==> Using real Redis-server at #{Pause::Redis::Adapter.redis.inspect}\n\n"
+  puts ; puts "NOTE: Using real Redis-server at #{Pause::Redis::Adapter.redis.inspect}\n\n"
 else
   require 'fakeredis/rspec'
 end
@@ -22,11 +19,12 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
+  rspec_dir = './.spec'.freeze
+  FileUtils.mkdir_p(rspec_dir)
+  config.example_status_persistence_file_path = "#{rspec_dir}/results.txt"
+
   config.order = 'random'
+
   if ENV['PAUSE_REAL_REDIS']
     config.before(:example) do
       Pause::Redis::Adapter.redis.flushdb

--- a/spec/support/fakeredis.rb
+++ b/spec/support/fakeredis.rb
@@ -1,2 +1,0 @@
-require 'fakeredis/rspec'
-


### PR DESCRIPTION
We are using Pause on a project, and I was getting an error that seemed like a redis error. Without being able to run specs against a real redis server, it was impossible to tell if the problem was with the gem or somewhere else.

Now the entire spec suite can run using `fakeredis` (the default), and against a local redis instance. 

To access integration tests, run `rake spec:integration` instead of `rake spec`.

Additionally, refactored the `Pause::Action` to stop using a class variable, which are [considered harmful](http://archive.oreilly.com/pub/a/ruby/excerpts/ruby-best-practices/worst-practices.html).

Updated Travis config to run against ruby 2.4.0, and to run both test suites.